### PR TITLE
Pin matplotlib to 3.7.3

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 mne==1.3.1
 numpy==1.23.5
-matplotlib
+matplotlib==3.7.3
 scikit-learn
 python-json-logger
 h5io


### PR DESCRIPTION
Pin matplotlib to 3.7.3 for now. To unpin, must also upgrade mne.