### PR TITLE
Fix TFR channel average - baseline order

### DIFF
--- a/meggie/actions/tfr_plot/controller/tfr.py
+++ b/meggie/actions/tfr_plot/controller/tfr.py
@@ -10,7 +10,7 @@ from meggie.utilities.channels import average_to_channel_groups
 from meggie.utilities.plotting import set_figure_title
 
 
-def plot_tfr_averages(subject, tfr_name, tfr_condition, 
+def plot_tfr_averages(subject, tfr_name, tfr_condition,
                       blmode, blstart, blend,
                       tmin, tmax, fmin, fmax, channel_groups):
     """ Plots tfr averages.
@@ -27,16 +27,14 @@ def plot_tfr_averages(subject, tfr_name, tfr_condition,
 
     tfr = meggie_tfr.content.get(tfr_condition)
 
-    data = tfr.data
     ch_names = meggie_tfr.ch_names
 
     sfreq = meggie_tfr.info['sfreq']
     times = meggie_tfr.times
     freqs = meggie_tfr.freqs
 
-    # compared to spectrums, evoked and tse, tfr is plotted with only one condition.
-    # it makes the plotting a bit simpler. we will also misuse 
-    # AverageTFR object to do the heavy work.
+    # note: baseline is corrected before channel average
+    data = mne.baseline.rescale(tfr.data, times, baseline=bline, mode=mode)
 
     data_labels, averaged_data = average_to_channel_groups(
         data, meggie_tfr.info, ch_names, channel_groups)
@@ -64,15 +62,15 @@ def plot_tfr_averages(subject, tfr_name, tfr_condition,
                 pass
             tfr._onselect = onselect
 
-            tfr.plot(baseline=bline, mode=mode, title='', 
-                     fmin=fmin, fmax=fmax, 
+            tfr.plot(baseline=None, title='',
+                     fmin=fmin, fmax=fmax,
                      tmin=tmin, tmax=tmax, axes=ax)
 
         title = ' '.join([tfr_name, tfr_condition, ch_type])
         create_channel_average_plot(len(ch_groups), plot_fun, title)
 
 
-def plot_tfr_topo(subject, tfr_name, tfr_condition, 
+def plot_tfr_topo(subject, tfr_name, tfr_condition,
                   blmode, blstart, blend,
                   tmin, tmax, fmin, fmax, ch_type):
     """ Plots tfr topography.

--- a/meggie/actions/tfr_plot_tse/controller/tfr.py
+++ b/meggie/actions/tfr_plot_tse/controller/tfr.py
@@ -135,11 +135,13 @@ def plot_tse_averages(subject, tfr_name, blmode, blstart, blend,
 
     averages = {}
     for key, tse in sorted(tses.items()):
-        data_labels, averaged_data = average_to_channel_groups(
-            tse, info, ch_names, channel_groups)
 
-        times, averaged_data = _crop_and_correct_to_baseline(
-            averaged_data, blmode, blstart, blend, tmin, tmax, meggie_tfr.times)
+        # note: baseline is corrected before channel average
+        times, ch_data = _crop_and_correct_to_baseline(
+            tse, blmode, blstart, blend, tmin, tmax, meggie_tfr.times)
+
+        data_labels, averaged_data = average_to_channel_groups(
+            ch_data, info, ch_names, channel_groups)
 
         for label_idx, label in enumerate(data_labels):
             if not label in averages:

--- a/meggie/actions/tfr_save/controller/tfr.py
+++ b/meggie/actions/tfr_save/controller/tfr.py
@@ -105,6 +105,7 @@ def save_tfr_channel_averages(experiment, tfr_name,
             column_names = format_floats(times)
             freqs = format_floats(mne_tfr.freqs)
 
+            # note: baseline is corrected before channel average
             data = mne.baseline.rescale(mne_tfr.data, times, baseline=bline,
                                         mode=mode)
 

--- a/meggie/actions/tfr_save_tse/controller/tfr.py
+++ b/meggie/actions/tfr_save_tse/controller/tfr.py
@@ -45,7 +45,7 @@ def _crop_and_correct_to_baseline(tse, blmode, blstart, blend, tmin, tmax, times
                 'Baseline end should not be later than crop end.')
 
         # correct to baseline
-        tse = mne.baseline.rescale(tse, times, baseline=(blstart, blend), 
+        tse = mne.baseline.rescale(tse, times, baseline=(blstart, blend),
                                    mode=blmode)
 
         # crop
@@ -111,11 +111,12 @@ def save_tse_channel_averages(experiment, tfr_name, blmode, blstart,
 
         for key, tse in tses.items():
 
-            data_labels, averaged_data = average_to_channel_groups(
-                tse, tfr.info, tfr.ch_names, channel_groups)
+            # note: baseline is corrected before channel average
+            times, ch_data = _crop_and_correct_to_baseline(
+                tse, blmode, blstart, blend, tmin, tmax, tfr.times)
 
-            times, averaged_data = _crop_and_correct_to_baseline(
-                averaged_data, blmode, blstart, blend, tmin, tmax, tfr.times)
+            data_labels, averaged_data = average_to_channel_groups(
+                ch_data, tfr.info, tfr.ch_names, channel_groups)
 
             csv_data.extend(averaged_data.tolist())
 


### PR DESCRIPTION
Makes meggie consistent across all induced response channel averages: baseline is corrected before averaging over channels.