### PR TITLE
Test actions

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -30,4 +30,4 @@ jobs:
 
     - name: Run tests
       run: |
-        nosetests
+        make test

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -24,6 +24,10 @@ jobs:
         pip install -r requirements.txt
         pip install -r dev-requirements.txt
 
+    - name: Install meggie for tests
+      run: |
+        pip install .
+
     - name: Check styles
       run: |
         make check

--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,10 @@ check:
 	black --check -t py39 meggie
 	pylama meggie
 
+.PHONY: test
+test:
+	pytest -s
+
 .PHONY: update_docs
 update_docs:
 	rm -fr docs_updated

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,4 +1,5 @@
 black
 pylama
-nose
+pytest
+pytest-qt
 mkdocs

--- a/meggie/actions/epochs_create/tests/test_epochs_create.py
+++ b/meggie/actions/epochs_create/tests/test_epochs_create.py
@@ -1,0 +1,34 @@
+from PyQt5 import QtWidgets
+
+from meggie.utilities.testing import BaseTestAction
+from meggie.actions.epochs_create import CreateEpochs
+from meggie.actions.epochs_create.dialogs.createEpochsFromEventsDialogMain import (
+    CreateEpochsFromEventsDialog,
+)
+
+
+class TestEpochsCreate(BaseTestAction):
+
+    def test_create_epochs_dialog(self):
+
+        def patched_exc_messagebox(parent, exc, exec_=False):
+            raise exc
+
+        self.monkeypatch.setattr(
+            "meggie.actions.epochs_create.dialogs.createEpochsFromEventsDialogMain.exc_messagebox",
+            patched_exc_messagebox,
+        )
+
+        self.run_action(
+            tab_id="epochs", action_name="epochs_create", handler=CreateEpochs
+        )
+        dialog = self.find_dialog(CreateEpochsFromEventsDialog)
+
+        event = {"event_id": 1, "mask": 0}
+        item = QtWidgets.QListWidgetItem(
+            "%s, %s" % ("ID " + str(event["event_id"]), "mask=" + str(event["mask"]))
+        )
+        dialog.ui.listWidgetEvents.addItem(item)
+        dialog.events = [event]
+
+        dialog.accept()

--- a/meggie/actions/epochs_create/tests/test_epochs_create.py
+++ b/meggie/actions/epochs_create/tests/test_epochs_create.py
@@ -8,9 +8,7 @@ from meggie.actions.epochs_create.dialogs.createEpochsFromEventsDialogMain impor
 
 
 class TestEpochsCreate(BaseTestAction):
-
     def test_create_epochs_dialog(self):
-
         def patched_exc_messagebox(parent, exc, exec_=False):
             raise exc
 

--- a/meggie/actions/tfr_plot_tse/__init__.py
+++ b/meggie/actions/tfr_plot_tse/__init__.py
@@ -14,7 +14,6 @@ from meggie.actions.tfr_plot_tse.controller.tfr import plot_tse_topo
 
 
 class PlotTSE(Action):
-
     def run(self):
         """Plots a TSE from TFR object."""
         try:

--- a/meggie/utilities/testing.py
+++ b/meggie/utilities/testing.py
@@ -1,6 +1,3 @@
-import os
-os.environ['QT_QPA_PLATFORM'] = 'offscreen'
-
 import tempfile
 import pytest
 import json
@@ -10,6 +7,8 @@ import pkg_resources
 from PyQt5.QtWidgets import QApplication, QMainWindow
 
 from meggie.utilities.generate_experiments import create_evoked_conditions_experiment
+
+os.environ["QT_QPA_PLATFORM"] = "offscreen"
 
 
 class MockMainWindow(QMainWindow):
@@ -35,7 +34,7 @@ def load_action_spec(action_name):
 class BaseTestAction:
     @pytest.fixture(autouse=True)
     def setup_common(self, qtbot, monkeypatch):
-        os.environ['QT_QPA_PLATFORM'] = 'offscreen'
+        os.environ["QT_QPA_PLATFORM"] = "offscreen"
         self.qtbot = qtbot
         self.monkeypatch = monkeypatch
         self.mock_main_window = MockMainWindow()

--- a/meggie/utilities/testing.py
+++ b/meggie/utilities/testing.py
@@ -1,0 +1,68 @@
+import os
+os.environ['QT_QPA_PLATFORM'] = 'offscreen'
+
+import tempfile
+import pytest
+import json
+import os
+import pkg_resources
+
+from PyQt5.QtWidgets import QApplication, QMainWindow
+
+from meggie.utilities.generate_experiments import create_evoked_conditions_experiment
+
+
+class MockMainWindow(QMainWindow):
+    def __init__(self, *args, **kwargs):
+        self.ui = None
+        QMainWindow.__init__(self)
+
+    def update_ui(self):
+        pass
+
+    def initialize_ui(self):
+        pass
+
+
+def load_action_spec(action_name):
+    action_path = pkg_resources.resource_filename("meggie", "actions")
+    config_path = os.path.join(action_path, action_name, "configuration.json")
+    with open(config_path, "r") as f:
+        action_spec = json.load(f)
+    return action_spec
+
+
+class BaseTestAction:
+    @pytest.fixture(autouse=True)
+    def setup_common(self, qtbot, monkeypatch):
+        os.environ['QT_QPA_PLATFORM'] = 'offscreen'
+        self.qtbot = qtbot
+        self.monkeypatch = monkeypatch
+        self.mock_main_window = MockMainWindow()
+        with tempfile.TemporaryDirectory() as tmpdirname:
+            self.dirpath = tmpdirname
+            self.setup_experiment()
+            yield
+
+    def setup_experiment(self):
+        self.experiment = create_evoked_conditions_experiment(
+            self.dirpath, "test_experiment", n_subjects=1
+        )
+        self.experiment.activate_subject("sample_01-raw")
+
+    def run_action(self, tab_id, action_name, handler):
+        data = {"tab_id": tab_id}
+        action_spec = load_action_spec(action_name)
+        self.action_instance = handler(
+            self.experiment, data, self.mock_main_window, action_spec
+        )
+        self.action_instance.run()
+
+    def find_dialog(self, dialog_class):
+        dialog = None
+        for widget in QApplication.topLevelWidgets():
+            if isinstance(widget, dialog_class):
+                dialog = widget
+                break
+        assert dialog is not None
+        return dialog


### PR DESCRIPTION
Create a test case for the 'epochs_create' action, which simulates a user's workflow by initially creating the dialog and then invoking the 'accept' method, analogous to a user clicking the action button. Essentially, this mimics a user executing the action with the default parameters. Since 'epochs_create' may not have all the required parameters by default, this test also illustrates how to populate the dialog with additional parameters before confirmation.